### PR TITLE
Fix TypeError thrown when target state does not exist

### DIFF
--- a/angular-ui-router-default.js
+++ b/angular-ui-router-default.js
@@ -20,7 +20,7 @@ angular.module('ui.router.default', ['ui.router'])
 				var numRedirects = 0;
 				while(numRedirects++ < max_redirects) {
 					var target = this.get(to, this.$current);
-					if(target.abstract && target.abstract !== true) {
+					if(target && target.abstract && target.abstract !== true) {
 						var childState = target.abstract;
 						if(!angular.isString(childState)) {
 							childState = $injector.invoke(childState);

--- a/src/angular-ui-router-default.js
+++ b/src/angular-ui-router-default.js
@@ -8,7 +8,7 @@ angular.module('ui.router.default', ['ui.router'])
 				var numRedirects = 0;
 				while(numRedirects++ < max_redirects) {
 					var target = this.get(to, this.$current);
-					if(target.abstract && target.abstract !== true) {
+					if(target && target.abstract && target.abstract !== true) {
 						var childState = target.abstract;
 						if(!angular.isString(childState)) {
 							childState = $injector.invoke(childState);

--- a/test/angular-ui-router-default.spec.js
+++ b/test/angular-ui-router-default.spec.js
@@ -8,6 +8,27 @@ describe('navigating to state', function() {
 		$stateProvider = _$stateProvider_;
 	}));
 
+	describe("with non-existant absolute state", function() {
+		it("should throw an informative error", inject(function($state, $rootScope) {
+			expect(function() {
+				$state.go('somewhere'); $rootScope.$digest();
+			}).toThrowError(/^Could not resolve/);
+		}));
+	})
+
+	describe("with non-existant relative state", function() {
+		beforeEach(module(function($stateProvider) {
+			$stateProvider.state('base', {});
+		}));
+
+		it("should throw an informative error", inject(function($state, $rootScope) {
+			$state.go('base'); $rootScope.$digest();
+			expect(function() {
+				$state.go('.somewhere'); $rootScope.$digest();
+			}).toThrowError(/^Could not resolve/);
+		}));
+	})
+
 	describe("with abstract = false", function() {
 
 		beforeEach(module(function($stateProvider) {


### PR DESCRIPTION
When attempting to navigate to a state that does not exist, `angular-ui-router-default` throws a `TypeError` because the result of `this.get(to, this.$current)` is `null`. This pull request adds tests for that condition and fixes the issue.
